### PR TITLE
section may not be styled with a transition

### DIFF
--- a/addon/components/expander/index.js
+++ b/addon/components/expander/index.js
@@ -143,7 +143,8 @@ class ExpanderComponent extends Component {
 
   _waitForTransition() {
     return waitForAnimation(this.contentElement, {
-      transitionProperty: 'max-height'
+      transitionProperty: 'max-height',
+      maybe: true
     });
   }
 


### PR DESCRIPTION
For example, in the interests of a fast test run, we disable animations during tests. Doing means that the `transitionstart` event never fires, and so tests hang forever on section expansion (c.f. the `generator` test waiter)